### PR TITLE
Update FileMaker CI/CD workflow to remove twine installation step and…

### DIFF
--- a/.github/workflows/filemaker-ci-cd.yml
+++ b/.github/workflows/filemaker-ci-cd.yml
@@ -2,9 +2,6 @@ name: FileMaker Provider CI/CD
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main
@@ -56,18 +53,10 @@ jobs:
           cd filemaker
           python -m build
 
-      - name: Install twine
-        if: steps.check_version.outputs.exists != 'true'
-        run: pip install twine
-
       - name: Publish package to PyPI
         if: steps.check_version.outputs.exists != 'true'
-        uses: pypa/gh-action-pypi-publish@v1.6.0
-        with:
-          packages_dir: filemaker/dist/
-          password: ${{ secrets.PYPI_API_TOKEN }}
-          skip_existing: true
-          verbose: true
+        run: |
+          python -m twine upload --skip-existing filemaker/dist/* -u __token__ -p "${{ secrets.PYPI_API_TOKEN }}" --verbose
 
   build-docker-image:
     name: Build and Push Docker Image


### PR DESCRIPTION
### **User description**
… streamline package publishing


___

### **PR Type**
enhancement, configuration changes


___

### **Description**
- Removed the `twine` installation step from CI/CD workflow.

- Streamlined package publishing using a direct `twine` command.

- Adjusted event triggers for the workflow to exclude `push` events.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>filemaker-ci-cd.yml</strong><dd><code>Simplified and optimized FileMaker CI/CD workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/filemaker-ci-cd.yml

<li>Removed <code>twine</code> installation step from the workflow.<br> <li> Replaced <code>pypa/gh-action-pypi-publish</code> with a direct <code>twine</code> command.<br> <li> Modified workflow triggers to exclude <code>push</code> events.


</details>


  </td>
  <td><a href="https://github.com/ArkTCI/airflow-providers/pull/16/files#diff-fbc957a01be39d58ab74ae14eceb186cc1ab893e199f1632cf46be7b4b1ae1d1">+2/-13</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>