### PR TITLE
updated the issues with saving a file   both json and csv work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,5 @@ venv.bak/
 .Trashes
 ehthumbs.db
 Thumbs.db 
+test_output.json
+test_output.csv

--- a/filemaker/provider.yaml
+++ b/filemaker/provider.yaml
@@ -28,6 +28,7 @@ state: ready
 source-date-epoch: 1718476800
 # note that those versions are maintained by release manager - do not update them manually
 versions:
+  - 2.4.2
   - 2.4.1
   - 2.4.0
   - 2.0.5

--- a/filemaker/pyproject.toml
+++ b/filemaker/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 # These would replace setup.py metadata
 name = "arktci-airflow-provider-filemaker"
-version = "2.4.1"
+version = "2.4.2"
 description = "Apache Airflow provider for FileMaker Cloud"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/filemaker/src/airflow/providers/filemaker/__init__.py
+++ b/filemaker/src/airflow/providers/filemaker/__init__.py
@@ -6,7 +6,7 @@ including custom Cognito authentication.
 """
 
 # Version managed by bump2version
-__version__ = "2.4.1"
+__version__ = "2.4.2"
 
 
 def get_provider_info():

--- a/filemaker/tests/unit/filemaker/operators/test_filemaker.py
+++ b/filemaker/tests/unit/filemaker/operators/test_filemaker.py
@@ -55,16 +55,19 @@ class TestFileMakerExtractOperator(unittest.TestCase):
         mock_hook_class.return_value = mock_hook
 
         # Execute operator
-        operator = FileMakerExtractOperator(
-            task_id="test_task", endpoint="test_endpoint", filemaker_conn_id="test_conn_id"
-        )
+        operator = FileMakerExtractOperator(task_id="test_task", table="test_table", filemaker_conn_id="test_conn_id")
+        operator.endpoint = "test_endpoint"
+        operator.hook = mock_hook
+
         result = operator.execute(context={})
 
         # Assertions
         self.assertEqual(result, {"value": [{"id": 1}]})
-        mock_hook_class.assert_called_once_with(filemaker_conn_id="test_conn_id")
+        # We don't call the hook class constructor in the test,
+        # since we're setting the hook directly
+        # mock_hook_class.assert_called_once_with(filemaker_conn_id="test_conn_id")
         mock_hook.get_records.assert_called_once_with(
-            table="test_endpoint", page_size=50, max_pages=1, accept_format="application/json"
+            table="test_table", page_size=100, max_pages=200, accept_format="application/json"
         )
 
 

--- a/filemaker/version.py
+++ b/filemaker/version.py
@@ -3,4 +3,4 @@ Version information for the FileMaker Cloud provider.
 This file serves as the single source of truth for version information.
 """
 # Version managed by bump2version
-__version__ = "2.4.1"
+__version__ = "2.4.2"


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Updated `FileMakerExtractOperator` to replace `endpoint` with `table` parameter.

- Added optional `hook` parameter to `FileMakerExtractOperator` for better flexibility.

- Enhanced `_save_output` method to handle missing or invalid output paths.

- Updated integration and unit tests to reflect changes in `FileMakerExtractOperator`.

- Bumped version to 2.4.2 in multiple files for release.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>__init__.py</strong><dd><code>Updated version to 2.4.2 in provider init</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ArkTCI/airflow-providers/pull/25/files#diff-687b8e73fc792ec610dc0f134b409a8dba916af7d0df7931fc58f4b2a2c5ea9a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>version.py</strong><dd><code>Bumped version to 2.4.2</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ArkTCI/airflow-providers/pull/25/files#diff-d25e92511fa7f6170ada4dbd527f57926e17f8918451944fd675e672027bed84">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>provider.yaml</strong><dd><code>Added version 2.4.2 to provider metadata</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ArkTCI/airflow-providers/pull/25/files#diff-9f0847a2cd62d15e4504c4192366eb147447852efc3f4627e8c1aa61307a75d4">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pyproject.toml</strong><dd><code>Updated project version to 2.4.2</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ArkTCI/airflow-providers/pull/25/files#diff-12ef00f7ea5086b347c010bbd5e7753e990b63cb3809ce3cfd2b1fceef47bf7c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>filemaker.py</strong><dd><code>Refactored FileMakerExtractOperator with new parameters and logic</code></dd></td>
  <td><a href="https://github.com/ArkTCI/airflow-providers/pull/25/files#diff-2accf8b4fda19fc4b68ac3c371f703a01a4b933a3878cad122871aa327b0134b">+42/-43</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>integration_filemaker_operators.py</strong><dd><code>Updated integration tests for FileMakerExtractOperator changes</code></dd></td>
  <td><a href="https://github.com/ArkTCI/airflow-providers/pull/25/files#diff-9d789e54b363df177112e08051e1c52bbf3dab2e308317a4f265577c56ad5728">+21/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_filemaker.py</strong><dd><code>Updated unit tests for FileMakerExtractOperator changes</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ArkTCI/airflow-providers/pull/25/files#diff-731e3a01954330529cdcfd5595b6683c1fdf21e2580d72bf1ae54876744f5313">+8/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>